### PR TITLE
Fixed issue #195, Compatibility with Python 3.10

### DIFF
--- a/messytables/core.py
+++ b/messytables/core.py
@@ -1,5 +1,8 @@
 from messytables.util import OrderedDict
-from collections import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 from messytables.error import TableError, NoSuchPropertyError
 import io
 from messytables.compat23 import *


### PR DESCRIPTION
Pulling relevant enhancements required to messytables to resolve issue with tap-s3-csv.